### PR TITLE
Add 3.2.x and apt-key for CRAN

### DIFF
--- a/3.0.1/Dockerfile
+++ b/3.0.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.0.1
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.0.1-6precise0 r-base-dev=3.0.1-6precise0
+RUN apt-get install -y r-base-core=3.0.1-6precise0 r-base-dev=3.0.1-6precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.0.2/Dockerfile
+++ b/3.0.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.0.2
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.0.2-1precise0 r-base-dev=3.0.2-1precise0
+RUN apt-get install -y r-base-core=3.0.2-1precise0 r-base-dev=3.0.2-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.0.3/Dockerfile
+++ b/3.0.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.0.3
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.0.3-1precise0 r-base-dev=3.0.3-1precise0
+RUN apt-get install -y r-base-core=3.0.3-1precise0 r-base-dev=3.0.3-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.1.0/Dockerfile
+++ b/3.1.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.1.0
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.1.0-1precise0 r-base-dev=3.1.0-1precise0
+RUN apt-get install -y r-base-core=3.1.0-1precise0 r-base-dev=3.1.0-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.1.1/Dockerfile
+++ b/3.1.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.1.1
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.1.1-1precise0 r-base-dev=3.1.1-1precise0
+RUN apt-get install -y r-base-core=3.1.1-1precise0 r-base-dev=3.1.1-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.1.2/Dockerfile
+++ b/3.1.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.1.2
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.1.2-1precise0 r-base-dev=3.1.2-1precise0
+RUN apt-get install -y r-base-core=3.1.2-1precise0 r-base-dev=3.1.2-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.1.3/Dockerfile
+++ b/3.1.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chad Barraford <chad@rstudio.com>
 ENV R_VERSION 3.1.3
 
 # Install R
-RUN apt-get -y --force-yes install r-base-core=3.1.3-1precise0 r-base-dev=3.1.3-1precise0
+RUN apt-get install -y r-base-core=3.1.3-1precise0 r-base-dev=3.1.3-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.2.0/Dockerfile
+++ b/3.2.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM cbarraford/r3x:base
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
-ENV R_VERSION 3.0.0
+ENV R_VERSION 3.2.0
 
 # Install R
-RUN apt-get install -y r-base-core=3.0.0-2precise r-base-dev=3.0.0-2precise
+RUN apt-get install -y r-base-core=3.2.0-4precise0 r-base-dev=3.2.0-4precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.2.1/Dockerfile
+++ b/3.2.1/Dockerfile
@@ -1,10 +1,10 @@
 FROM cbarraford/r3x:base
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
-ENV R_VERSION 3.0.0
+ENV R_VERSION 3.2.1
 
 # Install R
-RUN apt-get install -y r-base-core=3.0.0-2precise r-base-dev=3.0.0-2precise
+RUN apt-get install -y r-base-core=3.2.1-4precise0 r-base-dev=3.2.1-4precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.2.2/Dockerfile
+++ b/3.2.2/Dockerfile
@@ -1,10 +1,10 @@
 FROM cbarraford/r3x:base
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
-ENV R_VERSION 3.0.0
+ENV R_VERSION 3.2.2
 
 # Install R
-RUN apt-get install -y r-base-core=3.0.0-2precise r-base-dev=3.0.0-2precise
+RUN apt-get install -y r-base-core=3.2.2-1precise0 r-base-dev=3.2.2-1precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.2.3/Dockerfile
+++ b/3.2.3/Dockerfile
@@ -1,10 +1,10 @@
 FROM cbarraford/r3x:base
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
-ENV R_VERSION 3.0.0
+ENV R_VERSION 3.2.3
 
 # Install R
-RUN apt-get install -y r-base-core=3.0.0-2precise r-base-dev=3.0.0-2precise
+RUN apt-get install -y r-base-core=3.2.3-6precise0 r-base-dev=3.2.3-6precise0
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/3.2.4/Dockerfile
+++ b/3.2.4/Dockerfile
@@ -1,10 +1,10 @@
 FROM cbarraford/r3x:base
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
-ENV R_VERSION 3.0.0
+ENV R_VERSION 3.2.4
 
 # Install R
-RUN apt-get install -y r-base-core=3.0.0-2precise r-base-dev=3.0.0-2precise
+RUN apt-get install -y r-base-core=3.2.4-1precise r-base-dev=3.2.4-1precise
 
 # set UTF-8
 RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,47 @@
 FROM ubuntu:12.04
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
-# Enable apt mirrors
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt precise main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt precise-updates main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt precise-security main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
-
-# Add R apt repository
-RUN echo "deb http://cran.rstudio.com/bin/linux/ubuntu precise/" >> /etc/apt/sources.list
+# add R apt repository
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+RUN echo "deb http://cran.rstudio.com/bin/linux/ubuntu precise/" >> /etc/apt/sources.list.d/cran-rstudio.list
 
 # Update apt
-RUN apt-get -y -qq update
+RUN apt-get update -qq && \
+    apt-get install -y \
+    biblatex \
+    curl \
+    jags \
+    libatlas3gf-base \
+    libcairo2 \
+    libcairo2-dev \
+    libfftw3-dev \
+    libgdal1-dev \
+    libgraphviz-dev \
+    libmyodbc \
+    libmysqlclient15-dev \
+    libnetcdf-dev \
+    libproc-dev \
+    libproj-dev \
+    libprotoc-dev \
+    libxml2-dev \
+    libxt-dev \
+    libxt6 \
+    lsb-release \
+    odbc-postgresql \
+    protobuf-compiler \
+    sudo \
+    tdsodbc \
+    texinfo \
+    texlive \
+    texlive-bibtex-extra \
+    texlive-fonts-extra \
+    texlive-latex-extra \
+    texlive-xetex \
+    unixodbc \
+    unixodbc-dev \
+    wget
 
-RUN apt-get -y --force-yes --no-install-recommends install openjdk-7-jdk
-
-# Install add-on packages
-RUN apt-get -y --force-yes install sudo lsb-release curl wget libatlas3gf-base texinfo texlive texlive-fonts-extra texlive-latex-extra biblatex texlive-bibtex-extra texlive-xetex libxml2-dev protobuf-compiler libprotoc-dev libmysqlclient15-dev unixodbc unixodbc-dev libmyodbc odbc-postgresql tdsodbc libgraphviz-dev libproj-dev libfftw3-dev libnetcdf-dev libproc-dev libgdal1-dev libcairo2 libcairo2-dev libxt6 libxt-dev jags
+RUN apt-get install -y --no-install-recommends openjdk-7-jdk
 
 # Set default locale
 RUN update-locale --reset LANG=C.UTF-8

--- a/README.md
+++ b/README.md
@@ -3,41 +3,41 @@ docker-R3.X
 
 Ubuntu 12.04 image with [R](http://www.r-project.org/) 3.X preinstalled. Individually tagged versions of [this image](https://registry.hub.docker.com/u/cbarraford/r3x/) are built with a specific version of R installed.
 
-If you use the `latest` tag, you'll have the latest version of R which currently is 3.1.1.
+If you use the `latest` tag, you'll have the latest version of R which currently is 3.2.4.
 
 The LANG is set to use UTF-8 encoding so its internationally friendly.
 
 The following package list is installed to support commonly used R packages that have system layer dependencies.
 
- * sudo
- * lsb-release
- * curl
- * wget
- * libatlas3gf-base
- * texinfo
- * texlive
- * texlive-fonts-extra
- * texlive-latex-extra
  * biblatex
- * texlive-bibtex-extra
- * texlive-xetex
- * libxml2-dev
- * protobuf-compiler
- * libprotoc-dev
- * libmysqlclient15-dev
- * unixodbc
- * unixodbc-dev
- * libmyodbc
- * odbc-postgresql
- * tdsodbc
- * libgraphviz-dev
- * libproj-dev
- * libfftw3-dev
- * libnetcdf-dev
- * libproc-dev
- * libgdal1-dev
+ * curl
+ * jags
+ * libatlas3gf-base
  * libcairo2
  * libcairo2-dev
- * libxt6
+ * libfftw3-dev
+ * libgdal1-dev
+ * libgraphviz-dev
+ * libmyodbc
+ * libmysqlclient15-dev
+ * libnetcdf-dev
+ * libproc-dev
+ * libproj-dev
+ * libprotoc-dev
+ * libxml2-dev
  * libxt-dev
- * jags
+ * libxt6
+ * lsb-release
+ * odbc-postgresql
+ * protobuf-compiler
+ * sudo
+ * tdsodbc
+ * texinfo
+ * texlive
+ * texlive-bibtex-extra
+ * texlive-fonts-extra
+ * texlive-latex-extra
+ * texlive-xetex
+ * unixodbc
+ * unixodbc-dev
+ * wget


### PR DESCRIPTION
- Using the `apt-key` allows the removal of `--force-yes` which is documented as dangerous
- Normalize `-y` after `install`
- Sort the `apt-get install` packages
- Remove attempt to use apt mirror: it needs to appear at the top of the file, and currently scalablesdns.com fails
